### PR TITLE
Align ISO build configuration with Debian Bookworm

### DIFF
--- a/iso/README.md
+++ b/iso/README.md
@@ -1,2 +1,9 @@
 Live-build config for the SeniorenSlim ISO. Trigger the workflow manually or push to iso/**.
 
+## Base distribution
+
+The ISO targets **Debian 12 (Bookworm)**. The package selection (`config/package-lists`) and
+the security-normalising hooks (`config/hooks/normal`) are tailored to Debian's repository
+layout, so Bookworm keeps the live-build configuration aligned with the expected package
+names and mirror structure.
+

--- a/iso/auto/config
+++ b/iso/auto/config
@@ -3,11 +3,11 @@ set -e
 
 # Live-build config via auto/config (zonder niet-bestaande opties)
 lb config noauto \
-  --mode ubuntu \
-  --distribution jammy \
+  --mode debian \
+  --distribution bookworm \
   --architectures amd64 \
   --binary-images iso-hybrid \
-  --archive-areas "main restricted universe multiverse" \
-  --mirror-bootstrap http://archive.ubuntu.com/ubuntu \
-  --mirror-chroot    http://archive.ubuntu.com/ubuntu \
-  --mirror-binary    http://archive.ubuntu.com/ubuntu
+  --archive-areas "main contrib non-free non-free-firmware" \
+  --mirror-bootstrap http://deb.debian.org/debian \
+  --mirror-chroot    http://deb.debian.org/debian \
+  --mirror-binary    http://deb.debian.org/debian


### PR DESCRIPTION
## Summary
- document that the ISO build targets Debian 12 (Bookworm)
- update the live-build auto configuration to use Debian mirrors and suites

## Testing
- bash scripts/B_build_iso.fixed2.sh *(fails: live-build not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1775764a083288fdb5d56c68ddf9e