### PR TITLE
Use cat to install update-buddy script

### DIFF
--- a/scripts/B_postinstall_hooks.sh
+++ b/scripts/B_postinstall_hooks.sh
@@ -40,7 +40,7 @@ ufw allow 21115/tcp || true
 yes | ufw enable || true
 
 # Update-buddy
-install -m 755 /usr/local/bin/update-buddy <<'SH'
+cat <<'SH' >/usr/local/bin/update-buddy
 #!/usr/bin/env bash
 set -euo pipefail
 if ! command -v apt >/dev/null 2>&1; then exit 0; fi
@@ -50,4 +50,5 @@ apt dist-upgrade -y || true
 apt autoremove -y || true
 notify-send "SeniorenSlim" "Je computer is bijgewerkt en weer veilig. 👍" || true
 SH
+chmod 755 /usr/local/bin/update-buddy
 (crontab -l 2>/dev/null; echo "0 10 * * * /usr/local/bin/update-buddy >/var/log/update-buddy.log 2>&1") | crontab - || true


### PR DESCRIPTION
## Summary
- replace the install heredoc with a cat redirection when writing /usr/local/bin/update-buddy
- ensure the script's permissions are set explicitly with chmod after writing the file

## Testing
- PATH="/tmp/stubs:$PATH" bash scripts/B_postinstall_hooks.sh


------
https://chatgpt.com/codex/tasks/task_e_68d17733f2e083289f1b3e6288f8c5f0