### PR TITLE
Fix welcome autostart to open Markdown quickstart

### DIFF
--- a/config/desktop/skeleton/.config/autostart/seniorenslim-welcome.desktop
+++ b/config/desktop/skeleton/.config/autostart/seniorenslim-welcome.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
 Name=Welkom bij SeniorenSlim
-Exec=xdg-open /usr/share/seniorenslim/docs/quickstart.pdf
+Exec=xdg-open /usr/share/seniorenslim/docs/quickstart.md
 X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
## Summary
- update the welcome autostart desktop entry to open the Markdown quickstart file that the configurator installs

## Testing
- bash /tmp/A_configurator_install_local.sh

------
https://chatgpt.com/codex/tasks/task_e_68d17724bd1c832895e4026d8cada668