### PR TITLE
Fix project dir defaults for ISO scripts

### DIFF
--- a/build_iso_full.sh
+++ b/build_iso_full.sh
@@ -22,7 +22,13 @@ set -euo pipefail
 # ------------------------------------------------------------
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+PROJECT_DIR_PARENT="$(dirname "$SCRIPT_DIR")"
+if [[ -d "$PROJECT_DIR_PARENT/isolinux" ]]; then
+  PROJECT_DIR_DEFAULT="$PROJECT_DIR_PARENT"
+else
+  PROJECT_DIR_DEFAULT="$SCRIPT_DIR"
+fi
+PROJECT_DIR="${PROJECT_DIR:-$PROJECT_DIR_DEFAULT}"
 
 # === Jij past vooral deze aan =================================================
 STAGING_SRC="${STAGING_SRC:-$PROJECT_DIR/staging_root}"

--- a/scripts/B_build_iso.sh
+++ b/scripts/B_build_iso.sh
@@ -21,7 +21,8 @@ set -euo pipefail
 
 # Locaties instellen
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+PROJECT_DIR_DEFAULT="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="${PROJECT_DIR:-$PROJECT_DIR_DEFAULT}"
 ISO_SRC_DIR="${ISO_SRC_DIR:-$PROJECT_DIR/isolinux}"
 ALLOW_FALLBACK="${ALLOW_FALLBACK:-1}"
 


### PR DESCRIPTION
## Summary
- default `PROJECT_DIR` in the helper scripts to the project root so the bundled isolinux assets are picked up automatically
- make `build_iso_full.sh` fall back to its own directory when no `isolinux/` exists one level up, keeping the script runnable from the repository root while still supporting the `scripts/` layout

## Testing
- `bash scripts/B_build_iso.sh "$tmpdir1"`
- `PATH="$fakebin:$PATH" bash build_iso_full.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d182caf0ac8328853de3bf4c060051