### PR TITLE
Adjust project root detection for ISO scripts

### DIFF
--- a/build_iso_full.sh
+++ b/build_iso_full.sh
@@ -22,7 +22,11 @@ set -euo pipefail
 # ------------------------------------------------------------
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+DEFAULT_PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+if [[ ! -d "$DEFAULT_PROJECT_DIR/isolinux" ]]; then
+  DEFAULT_PROJECT_DIR="$SCRIPT_DIR"
+fi
+PROJECT_DIR="${PROJECT_DIR:-$DEFAULT_PROJECT_DIR}"
 
 # === Jij past vooral deze aan =================================================
 STAGING_SRC="${STAGING_SRC:-$PROJECT_DIR/staging_root}"

--- a/scripts/B_build_iso.sh
+++ b/scripts/B_build_iso.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 # Locaties instellen
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+PROJECT_DIR="${PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
 ISO_SRC_DIR="${ISO_SRC_DIR:-$PROJECT_DIR/isolinux}"
 ALLOW_FALLBACK="${ALLOW_FALLBACK:-1}"
 


### PR DESCRIPTION
## Summary
- default `scripts/B_build_iso.sh` to treat the parent directory as the project root so `ISO_SRC_DIR` resolves to the tracked `isolinux` folder
- have `build_iso_full.sh` locate the project root from the parent of the script directory (with a fallback) so its staging/output defaults come from the repository root

## Testing
- `bash ./scripts/B_build_iso.sh /tmp/test_isolinux`
- `PATH="$(pwd)/fake_bin:$PATH" bash ./build_iso_full.sh` *(uses a stub `xorriso` because the real binary is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d182d6e67883289fe936f07c057391