### PR TITLE
Adjust Pandoc image styling to prevent cropping

### DIFF
--- a/assets/docs/pandoc.css
+++ b/assets/docs/pandoc.css
@@ -5,4 +5,9 @@ h2 { font-size: 20pt; margin-top: 24pt; }
 h3 { font-size: 16pt; margin-top: 18pt; }
 p, li { font-size: 13pt; }
 code, pre { font-size: 11pt; }
-img { max-width: 100%; }
+img {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+  object-position: center bottom;
+}


### PR DESCRIPTION
## Summary
- ensure generated documentation images maintain full visibility by containing and bottom-aligning them within their containers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f250f863688328b7586a1e2b38d06b